### PR TITLE
Update manifest.json for l10n URLs

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -8,12 +8,12 @@
   "content_scripts": [
     {
       "matches": [
-        "https://www.humblebundle.com/membership/*",
-        "https://www.humblebundle.com/games/*",
-        "https://www.humblebundle.com/software/*",
-        "https://www.humblebundle.com/home/keys*",
-        "https://www.humblebundle.com/home/library*",
-        "https://www.humblebundle.com/store*"
+        "https://*.humblebundle.com/membership/*",
+        "https://*.humblebundle.com/games/*",
+        "https://*.humblebundle.com/software/*",
+        "https://*.humblebundle.com/home/keys*",
+        "https://*.humblebundle.com/home/library*",
+        "https://*.humblebundle.com/store*"
       ],
       "css": ["main.css"],
       "js": ["browser-polyfill.min.js", "main.js"]


### PR DESCRIPTION
When going to HB via Google or via a different website it links to a (non-localized but) different URL. So for Germany as an example Google automatically sends you to "www.de.humblebundle.com". Because of this the extension doesn't load. 
(I don't know why HB does this but whatever)
-> Changing the matches already does the trick