### PR TITLE
Bugfix: submitting missing tags does not reference the same field twice

### DIFF
--- a/src/content/Suggestion.tsx
+++ b/src/content/Suggestion.tsx
@@ -17,7 +17,7 @@ const Suggestion = ({ close }: Props) => {
   );
 
   const steamName = useField('steam_name');
-  const humbleName = useField('steam_name');
+  const humbleName = useField('humble_name');
 
   return (
     <form


### PR DESCRIPTION
As mentioned in #19, the tag submission form references the same field twice for both the Steam and Humble names. This just corrects that to a separate field.